### PR TITLE
Adding concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+*.http

--- a/src/api/app/apis.go
+++ b/src/api/app/apis.go
@@ -7,5 +7,6 @@ import (
 
 func mapUrls() {
 	router.GET("/health", health.Health)
-	router.POST("/repositories", repositories.CreateRepo)
+	router.POST("/repository", repositories.CreateRepo)
+	router.POST("/repositories", repositories.CreateRepos)
 }

--- a/src/api/controllers/repositories/repositories_controller.go
+++ b/src/api/controllers/repositories/repositories_controller.go
@@ -25,3 +25,20 @@ func CreateRepo(c *gin.Context) {
 	}
 	c.JSON(http.StatusCreated, result)
 }
+
+// CreateRepos func
+func CreateRepos(c *gin.Context) {
+	var request []repositories.CreateRepoRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		apiErr := errors.NewBadRequestError("invalid json body")
+		c.JSON(apiErr.StatusFn(), apiErr)
+		return
+	}
+
+	result, err := services.RepositoryService.CreateRepos(request)
+	if err != nil {
+		c.JSON(err.StatusFn(), err)
+		return
+	}
+	c.JSON(result.StatusCode, result)
+}

--- a/src/api/domain/repositories/create_repo.go
+++ b/src/api/domain/repositories/create_repo.go
@@ -1,9 +1,24 @@
 package repositories
 
+import (
+	"strings"
+
+	"github.com/PS-07/go-microservices/src/api/utils/errors"
+)
+
 // CreateRepoRequest struct
 type CreateRepoRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+// Validate func
+func (req *CreateRepoRequest) Validate() errors.APIError {
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		return errors.NewBadRequestError("invalid repository name")
+	}
+	return nil
 }
 
 // CreateRepoResponse struct
@@ -11,4 +26,16 @@ type CreateRepoResponse struct {
 	ID    int64  `json:"id"`
 	Owner string `json:"owner"`
 	Name  string `json:"name"`
+}
+
+// CreateReposResponse struct
+type CreateReposResponse struct {
+	StatusCode int                `json:"status"`
+	Results    []CreateRepoResult `json:"results"`
+}
+
+// CreateRepoResult struct
+type CreateRepoResult struct {
+	Response *CreateRepoResponse `json:"repo"`
+	Error    errors.APIError     `json:"error"`
 }

--- a/src/api/services/repositories_service.go
+++ b/src/api/services/repositories_service.go
@@ -1,7 +1,8 @@
 package services
 
 import (
-	"strings"
+	"net/http"
+	"sync"
 
 	"github.com/PS-07/go-microservices/src/api/config"
 	"github.com/PS-07/go-microservices/src/api/domain/github"
@@ -14,6 +15,7 @@ type repoService struct{}
 
 type repoServiceInterface interface {
 	CreateRepo(repositories.CreateRepoRequest) (*repositories.CreateRepoResponse, errors.APIError)
+	CreateRepos([]repositories.CreateRepoRequest) (repositories.CreateReposResponse, errors.APIError)
 }
 
 var (
@@ -26,9 +28,8 @@ func init() {
 }
 
 func (s *repoService) CreateRepo(input repositories.CreateRepoRequest) (*repositories.CreateRepoResponse, errors.APIError) {
-	input.Name = strings.TrimSpace(input.Name)
-	if input.Name == "" {
-		return nil, errors.NewBadRequestError("invalid repository name")
+	if err := input.Validate(); err != nil {
+		return nil, err
 	}
 
 	request := github.CreateRepoRequest{
@@ -36,7 +37,6 @@ func (s *repoService) CreateRepo(input repositories.CreateRepoRequest) (*reposit
 		Description: input.Description,
 		Private:     false,
 	}
-
 	response, err := githubprovider.CreateRepo(config.GetGithubAccessToken(), request)
 	if err != nil {
 		return nil, errors.NewAPIError(err.StatusCode, err.Message)
@@ -48,4 +48,64 @@ func (s *repoService) CreateRepo(input repositories.CreateRepoRequest) (*reposit
 		Owner: response.Owner.Login,
 	}
 	return &result, nil
+}
+
+func (s *repoService) CreateRepos(requests []repositories.CreateRepoRequest) (repositories.CreateReposResponse, errors.APIError) {
+	var wg sync.WaitGroup
+	input := make(chan repositories.CreateRepoResult)
+	output := make(chan repositories.CreateReposResponse)
+	defer close(output)
+
+	go s.handleRepoResults(&wg, input, output)
+	for _, req := range requests {
+		wg.Add(1)
+		go s.createRepoConcurrent(req, input)
+	}
+
+	wg.Wait()
+	close(input)
+	result := <- output
+
+	successCreations := 0
+	for _, current := range result.Results {
+		if current.Response != nil {
+			successCreations++
+		}
+	}
+	if successCreations == 0 {
+		result.StatusCode = result.Results[0].Error.StatusFn()
+	} else if successCreations == len(requests) {
+		result.StatusCode = http.StatusCreated
+	} else {
+		result.StatusCode = http.StatusPartialContent
+	}
+
+	return result, nil
+}
+
+func (s *repoService) handleRepoResults(wg *sync.WaitGroup, input chan repositories.CreateRepoResult, output chan repositories.CreateReposResponse) {
+	var results repositories.CreateReposResponse
+
+	for incomingEvent := range input {
+		repoResult := repositories.CreateRepoResult{
+			Response: incomingEvent.Response,
+			Error: incomingEvent.Error,
+		}
+		results.Results = append(results.Results, repoResult)
+		wg.Done()
+	}
+	output <- results
+}
+
+func (s *repoService) createRepoConcurrent(req repositories.CreateRepoRequest, input chan repositories.CreateRepoResult) {
+	if err := req.Validate(); err != nil {
+		input <- repositories.CreateRepoResult{Error: err}
+		return
+	}
+	result, err := s.CreateRepo(req)
+	if err != nil {
+		input <- repositories.CreateRepoResult{Error: err}
+		return
+	}
+	input <- repositories.CreateRepoResult{Response: result}
 }

--- a/src/api/services/repositories_service.go
+++ b/src/api/services/repositories_service.go
@@ -64,7 +64,7 @@ func (s *repoService) CreateRepos(requests []repositories.CreateRepoRequest) (re
 
 	wg.Wait()
 	close(input)
-	result := <- output
+	result := <-output
 
 	successCreations := 0
 	for _, current := range result.Results {
@@ -89,7 +89,7 @@ func (s *repoService) handleRepoResults(wg *sync.WaitGroup, input chan repositor
 	for incomingEvent := range input {
 		repoResult := repositories.CreateRepoResult{
 			Response: incomingEvent.Response,
-			Error: incomingEvent.Error,
+			Error:    incomingEvent.Error,
 		}
 		results.Results = append(results.Results, repoResult)
 		wg.Done()

--- a/src/api/services/repositories_service_test.go
+++ b/src/api/services/repositories_service_test.go
@@ -79,9 +79,9 @@ func TestCreateRepoConcurrentInvalidRequest(t *testing.T) {
 	service := repoService{}
 	request := repositories.CreateRepoRequest{}
 	input := make(chan repositories.CreateRepoResult)
-	
+
 	go service.createRepoConcurrent(request, input)
-	result := <- input
+	result := <-input
 
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Response)
@@ -106,9 +106,9 @@ func TestCreateRepoConcurrentErrorFromGithub(t *testing.T) {
 	service := repoService{}
 	request := repositories.CreateRepoRequest{Name: "test-repo"}
 	input := make(chan repositories.CreateRepoResult)
-	
+
 	go service.createRepoConcurrent(request, input)
-	result := <- input
+	result := <-input
 
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Response)
@@ -134,9 +134,9 @@ func TestCreateRepoConcurrentNoError(t *testing.T) {
 	service := repoService{}
 	request := repositories.CreateRepoRequest{Name: "test-repo"}
 	input := make(chan repositories.CreateRepoResult)
-	
+
 	go service.createRepoConcurrent(request, input)
-	result := <- input
+	result := <-input
 
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error)
@@ -154,22 +154,22 @@ func TestHandleRepoResults(t *testing.T) {
 
 	service := repoService{}
 	go service.handleRepoResults(&wg, input, output)
-	
+
 	wg.Add(1)
 	go func() {
 		input <- repositories.CreateRepoResult{
 			Error: errors.NewBadRequestError("invalid repository name"),
 		}
-	} ()
+	}()
 
 	wg.Wait()
 	close(input)
-	result := <- output
+	result := <-output
 
 	assert.NotNil(t, result)
 	assert.EqualValues(t, 0, result.StatusCode)
 	assert.EqualValues(t, 1, len(result.Results))
-	assert.NotNil(t, result.Results[0].Error)	
+	assert.NotNil(t, result.Results[0].Error)
 	assert.EqualValues(t, http.StatusBadRequest, result.Results[0].Error.StatusFn())
 	assert.EqualValues(t, "invalid repository name", result.Results[0].Error.MessageFn())
 }

--- a/src/api/services/repositories_service_test.go
+++ b/src/api/services/repositories_service_test.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/PS-07/go-microservices/src/api/clients/rest"
 	"github.com/PS-07/go-microservices/src/api/domain/repositories"
+	"github.com/PS-07/go-microservices/src/api/utils/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,10 +42,7 @@ func TestCreateRepoErrorFromGithub(t *testing.T) {
 			}`)),
 		},
 	})
-
-	request := repositories.CreateRepoRequest{
-		Name: "test-repo",
-	}
+	request := repositories.CreateRepoRequest{Name: "test-repo"}
 	result, err := RepositoryService.CreateRepo(request)
 
 	assert.Nil(t, result)
@@ -66,10 +65,7 @@ func TestCreateRepoNoError(t *testing.T) {
 			}`)),
 		},
 	})
-
-	request := repositories.CreateRepoRequest{
-		Name: "test-repo",
-	}
+	request := repositories.CreateRepoRequest{Name: "test-repo"}
 	result, err := RepositoryService.CreateRepo(request)
 
 	assert.Nil(t, err)
@@ -77,4 +73,201 @@ func TestCreateRepoNoError(t *testing.T) {
 	assert.EqualValues(t, 123, result.ID)
 	assert.EqualValues(t, "test-repo", result.Name)
 	assert.EqualValues(t, "PS-07", result.Owner)
+}
+
+func TestCreateRepoConcurrentInvalidRequest(t *testing.T) {
+	service := repoService{}
+	request := repositories.CreateRepoRequest{}
+	input := make(chan repositories.CreateRepoResult)
+	
+	go service.createRepoConcurrent(request, input)
+	result := <- input
+
+	assert.NotNil(t, result)
+	assert.Nil(t, result.Response)
+	assert.NotNil(t, result.Error)
+	assert.EqualValues(t, http.StatusBadRequest, result.Error.StatusFn())
+	assert.EqualValues(t, "invalid repository name", result.Error.MessageFn())
+}
+
+func TestCreateRepoConcurrentErrorFromGithub(t *testing.T) {
+	rest.FlushMockups()
+	rest.AddMockup(rest.Mock{
+		URL:        "https://api.github.com/user/repos",
+		HTTPMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{
+				"message": "Requires authentication",
+				"documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-for-the-authenticated-user"
+			}`)),
+		},
+	})
+	service := repoService{}
+	request := repositories.CreateRepoRequest{Name: "test-repo"}
+	input := make(chan repositories.CreateRepoResult)
+	
+	go service.createRepoConcurrent(request, input)
+	result := <- input
+
+	assert.NotNil(t, result)
+	assert.Nil(t, result.Response)
+	assert.NotNil(t, result.Error)
+	assert.EqualValues(t, http.StatusUnauthorized, result.Error.StatusFn())
+	assert.EqualValues(t, "Requires authentication", result.Error.MessageFn())
+}
+
+func TestCreateRepoConcurrentNoError(t *testing.T) {
+	rest.FlushMockups()
+	rest.AddMockup(rest.Mock{
+		URL:        "https://api.github.com/user/repos",
+		HTTPMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{
+				"id": 123, 
+				"name": "test-repo",
+				"owner": {"login": "PS-07"}
+			}`)),
+		},
+	})
+	service := repoService{}
+	request := repositories.CreateRepoRequest{Name: "test-repo"}
+	input := make(chan repositories.CreateRepoResult)
+	
+	go service.createRepoConcurrent(request, input)
+	result := <- input
+
+	assert.NotNil(t, result)
+	assert.Nil(t, result.Error)
+	assert.NotNil(t, result.Response)
+	assert.EqualValues(t, 123, result.Response.ID)
+	assert.EqualValues(t, "test-repo", result.Response.Name)
+	assert.EqualValues(t, "PS-07", result.Response.Owner)
+}
+
+func TestHandleRepoResults(t *testing.T) {
+	var wg sync.WaitGroup
+	input := make(chan repositories.CreateRepoResult)
+	output := make(chan repositories.CreateReposResponse)
+	defer close(output)
+
+	service := repoService{}
+	go service.handleRepoResults(&wg, input, output)
+	
+	wg.Add(1)
+	go func() {
+		input <- repositories.CreateRepoResult{
+			Error: errors.NewBadRequestError("invalid repository name"),
+		}
+	} ()
+
+	wg.Wait()
+	close(input)
+	result := <- output
+
+	assert.NotNil(t, result)
+	assert.EqualValues(t, 0, result.StatusCode)
+	assert.EqualValues(t, 1, len(result.Results))
+	assert.NotNil(t, result.Results[0].Error)	
+	assert.EqualValues(t, http.StatusBadRequest, result.Results[0].Error.StatusFn())
+	assert.EqualValues(t, "invalid repository name", result.Results[0].Error.MessageFn())
+}
+
+func TestCreateReposInvalidRequests(t *testing.T) {
+	requests := []repositories.CreateRepoRequest{
+		{},
+		{Name: "   "},
+	}
+	result, err := RepositoryService.CreateRepos(requests)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.EqualValues(t, http.StatusBadRequest, result.StatusCode)
+	assert.EqualValues(t, 2, len(result.Results))
+
+	assert.Nil(t, result.Results[0].Response)
+	assert.EqualValues(t, http.StatusBadRequest, result.Results[0].Error.StatusFn())
+	assert.EqualValues(t, "invalid repository name", result.Results[0].Error.MessageFn())
+
+	assert.Nil(t, result.Results[1].Response)
+	assert.EqualValues(t, http.StatusBadRequest, result.Results[1].Error.StatusFn())
+	assert.EqualValues(t, "invalid repository name", result.Results[1].Error.MessageFn())
+}
+
+func TestCreateReposOneSuccessOneFailure(t *testing.T) {
+	rest.FlushMockups()
+	rest.AddMockup(rest.Mock{
+		URL:        "https://api.github.com/user/repos",
+		HTTPMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{
+				"id": 123, 
+				"name": "test-repo",
+				"owner": {"login": "PS-07"}
+			}`)),
+		},
+	})
+	requests := []repositories.CreateRepoRequest{
+		{},
+		{Name: "test-repo"},
+	}
+	result, err := RepositoryService.CreateRepos(requests)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.EqualValues(t, http.StatusPartialContent, result.StatusCode)
+	assert.EqualValues(t, 2, len(result.Results))
+
+	for _, result := range result.Results {
+		if result.Error != nil {
+			assert.EqualValues(t, http.StatusBadRequest, result.Error.StatusFn())
+			assert.EqualValues(t, "invalid repository name", result.Error.MessageFn())
+			continue
+		}
+		assert.EqualValues(t, 123, result.Response.ID)
+		assert.EqualValues(t, "test-repo", result.Response.Name)
+		assert.EqualValues(t, "PS-07", result.Response.Owner)
+	}
+}
+
+func TestCreateReposRepoAlreadyExistsFailure(t *testing.T) {
+	rest.FlushMockups()
+	rest.AddMockup(rest.Mock{
+		URL:        "https://api.github.com/user/repos",
+		HTTPMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{
+				"id": 123, 
+				"name": "test-repo",
+				"owner": {"login": "PS-07"}
+			}`)),
+		},
+	})
+
+	requests := []repositories.CreateRepoRequest{
+		{Name: "test-repo"},
+		{Name: "test-repo"},
+	}
+
+	result, err := RepositoryService.CreateRepos(requests)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.EqualValues(t, http.StatusPartialContent, result.StatusCode)
+	assert.EqualValues(t, 2, len(result.Results))
+
+	for _, result := range result.Results {
+		if result.Error != nil {
+			assert.EqualValues(t, http.StatusInternalServerError, result.Error.StatusFn())
+			assert.EqualValues(t, "error trying to unmarshal github create repo response", result.Error.MessageFn())
+			continue
+		}
+
+		assert.EqualValues(t, 123, result.Response.ID)
+		assert.EqualValues(t, "test-repo", result.Response.Name)
+		assert.EqualValues(t, "PS-07", result.Response.Owner)
+	}
 }


### PR DESCRIPTION
Adding support for multiple create repo requests on '/repositories' and handling them concurrently.